### PR TITLE
Update Shaman.lua

### DIFF
--- a/GS-DraikMacros/Macros/Shaman.lua
+++ b/GS-DraikMacros/Macros/Shaman.lua
@@ -160,11 +160,10 @@ helpTxt = 'Talents: 3313313',
 PreMacro=[[
 ]],
 "/castsequence [nochanneling]reset=30 Healing Stream Totem",
-"/castsequence [nopet,nodead][nochanneling,target=mouseover,help]reset=5 !Riptide",
-"/castsequence [nochanneling,target=mouseover,help]Healing Surge, Healing Surge, Healing Surge, Healing Surge",
-"/castsequence [nochanneling,target=mouseover,help]Healing Surge",
+"/castsequence [nochanneling,@mouseover,help,nodead]reset=5 !Riptide",
+"/castsequence [nochanneling,@mouseover,help]Healing Surge, Healing Surge, Healing Surge, Healing Surge",
+"/castsequence [nochanneling,@mouseover,help]Healing Surge",
 PostMacro=[[
-/startattack
 ]],
 }
 
@@ -175,11 +174,10 @@ helpTxt = 'Talents: 3313313',
 PreMacro=[[
 ]],
 "/castsequence [nochanneling]reset=30 Healing Stream Totem",
-"/castsequence [nopet,nodead][nochanneling,target=mouseover,help]reset=5 !Riptide",
-"/castsequence [nochanneling,target=mouseover,help]Healing Wave, Healing Wave, Healing Wave, Healing Wave",
-"/castsequence [nochanneling,target=mouseover,help]Healing Wave",
+"/castsequence [nochanneling,@mouseover,help]reset=5 !Riptide",
+"/castsequence [nochanneling,@mouseover,help]Healing Wave, Healing Wave, Healing Wave, Healing Wave",
+"/castsequence [nochanneling,@mouseover,help]Healing Wave",
 PostMacro=[[
-/startattack
 ]],
 }
 
@@ -190,10 +188,9 @@ helpTxt = 'Talents: 3313313',
 PreMacro=[[
 ]],
 "/castsequence [nochanneling]reset=30 Healing Stream Totem",
-"/castsequence [nopet,nodead][nochanneling,target=mouseover,help]reset=5 !Riptide",
-"/castsequence [nochanneling,target=mouseover,help]Chain Heal, Chain Heal, Chain Heal, Chain Heal",
-"/castsequence [nochanneling,target=mouseover,help]Healing Surge",
+"/castsequence [nochanneling,@mouseover,help,nodead]reset=5 !Riptide",
+"/castsequence [nochanneling,@mouseover,help]Chain Heal, Chain Heal, Chain Heal, Chain Heal",
+"/castsequence [nochanneling,@mouseover,help]Healing Surge",
 PostMacro=[[
-/startattack
 ]],
 }


### PR DESCRIPTION
/startattack was causing "You don't have a target" error sound even with sound option disabled.  Fixed mouseover, cleanup, can now cast Riptide on actual mouseover person.